### PR TITLE
fix rdb crash

### DIFF
--- a/src/ctrip_crdt_rdb.c
+++ b/src/ctrip_crdt_rdb.c
@@ -622,7 +622,7 @@ robj* reverseHashToArgv(hashTypeIterator* hi, int type) {
         }
     }else if(hi->encoding == OBJ_ENCODING_HT) {
         sds value = hashTypeCurrentFromHashTable(hi, type);
-        return createObject(OBJ_STRING, value);
+        return createObject(OBJ_STRING, sdsdup(value));
     }else{
         serverLog(LL_WARNING, "hash encoding error");
         return NULL;

--- a/tests/ctrip/master-not-crdt/convert-zipmap-hash-on-load.tcl
+++ b/tests/ctrip/master-not-crdt/convert-zipmap-hash-on-load.tcl
@@ -1,0 +1,41 @@
+# Copy RDB with zipmap encoded hash to server path
+set server_path [tmpdir "server.convert-zipmap-hash-on-load"]
+
+exec cp -f tests/assets/hash-zipmap.rdb $server_path
+exec cp -f tests/assets/crdt.so $server_path
+# start_server [list overrides [list "dir" $server_path "dbfilename" "hash-zipmap.rdb"]] {
+# start_server {tags {"ziplist"} overrides {crdt-gid 1  "dir" $server_path "dbfilename" "hash-zipmap.rdb"} config {crdt.conf} module {crdt.so} } {
+
+start_server [list overrides [list crdt-gid 1 loadmodule ./crdt.so  "dir"  $server_path "dbfilename" "hash-zipmap.rdb"]] {
+  test "RDB load zipmap hash: converts to ziplist" {
+    r select 0
+
+    # assert_match "*ziplist*" [r debug object hash]
+    # assert_equal 2 [r hlen hash]
+    assert_match {v1 v2} [r hmget hash f1 f2]
+  }
+}
+
+exec cp -f tests/assets/hash-zipmap.rdb $server_path
+# start_server [list overrides [list "dir" $server_path "dbfilename" "hash-zipmap.rdb" "hash-max-ziplist-entries" 1]] {
+start_server [list overrides [list crdt-gid 1 loadmodule ./crdt.so  "dir"  $server_path "dbfilename" "hash-zipmap.rdb" "hash-max-ziplist-entries" 1]] {
+   test "RDB load zipmap hash: converts to hash table when hash-max-ziplist-entries is exceeded" {
+    r select 0
+
+    # assert_match "*hashtable*" [r debug object hash]
+    # assert_equal 2 [r hlen hash]
+    assert_match {v1 v2} [r hmget hash f1 f2]
+  }
+}
+
+exec cp -f tests/assets/hash-zipmap.rdb $server_path
+# start_server [list overrides [list "dir" $server_path "dbfilename" "hash-zipmap.rdb" "hash-max-ziplist-value" 1]] {
+start_server [list overrides [list crdt-gid 1 loadmodule ./crdt.so  "dir"  $server_path "dbfilename" "hash-zipmap.rdb" "hash-max-ziplist-value" 1]] {
+  test "RDB load zipmap hash: converts to hash table when hash-max-ziplist-value is exceeded" {
+    r select 0
+
+    # assert_match "*hashtable*" [r debug object hash]
+    # assert_equal 2 [r hlen hash]
+    assert_match {v1 v2} [r hmget hash f1 f2]
+  }
+}

--- a/tests/test_crdt.tcl
+++ b/tests/test_crdt.tcl
@@ -14,6 +14,7 @@ source tests/support/aof.tcl
 
 
 set ::all_tests {
+    ctrip/master-not-crdt/convert-zipmap-hash-on-load
     ctrip/integration/bug/slave-non-read-only-peer-backlog
     ctrip/integration/composite/peer-offset-check
     ctrip/master-not-crdt/slave-update-peer-repl-offset


### PR DESCRIPTION
fix load non-crdt rdb crash, because  double free  key and value when load hash object and encoding = obj_encoding_ht, The first release of sds memory is when the hash object is released, and the second release of sds memory is in the hash command